### PR TITLE
Feat: Add more VS Code shortcuts and tips to cheat sheet

### DIFF
--- a/keyboard.html
+++ b/keyboard.html
@@ -407,6 +407,14 @@
                         <span class="shortcut-desc">Reveal in Explorer</span>
                         <span class="keys" data-win="Ctrl + K R" data-mac="Cmd + K R">Ctrl + K R</span>
                     </div>
+                    <div class="shortcut">
+                        <span class="shortcut-desc">File: Revert File (via Command Palette)</span>
+                        <span class="keys" data-win="Ctrl+Shift+P → File: Revert File" data-mac="Cmd+Shift+P → File: Revert File">Ctrl+Shift+P → File: Revert File</span>
+                    </div>
+                    <div class="pro-tip">
+                        <div class="pro-tip-title">💡 Pro Tip:</div>
+                        Use the "Timeline" view (Command Palette: `Timeline: Open Timeline` or find it in the Explorer context menu for a file) to see local file history, Git commits, and more for the current file.
+                    </div>
                     <div class="pro-tip">
                         <div class="pro-tip-title">💡 Pro Tip:</div>
                         Use Ctrl+P then type ">" to access Command Palette, or "@" for symbols, or ":" for line numbers!
@@ -458,6 +466,10 @@
                         <span class="keys" data-win="Alt + →" data-mac="Ctrl + Shift + -">Alt + →</span>
                     </div>
                     <div class="shortcut">
+                        <span class="shortcut-desc">Go to Last Edit Location</span>
+                        <span class="keys" data-win="Ctrl + K Ctrl + Q" data-mac="Cmd + K Cmd + Q">Ctrl + K Ctrl + Q</span>
+                    </div>
+                    <div class="shortcut">
                         <span class="shortcut-desc">Navigate to Next Tab</span>
                         <span class="keys" data-win="Ctrl + Tab" data-mac="Cmd + Alt + →">Ctrl + Tab</span>
                     </div>
@@ -468,6 +480,14 @@
                     <div class="shortcut">
                         <span class="shortcut-desc">Jump to Matching Bracket</span>
                         <span class="keys" data-win="Ctrl + Shift + \\" data-mac="Cmd + Shift + \\">Ctrl + Shift + \\</span>
+                    </div>
+                    <div class="shortcut">
+                        <span class="shortcut-desc">Fold All Regions</span>
+                        <span class="keys" data-win="Ctrl + K Ctrl + 0" data-mac="Cmd + K Cmd + 0">Ctrl + K Ctrl + 0</span>
+                    </div>
+                    <div class="shortcut">
+                        <span class="shortcut-desc">Unfold All Regions</span>
+                        <span class="keys" data-win="Ctrl + K Ctrl + J" data-mac="Cmd + K Cmd + J">Ctrl + K Ctrl + J</span>
                     </div>
                     <div class="shortcut">
                         <span class="shortcut-desc">Navigate to Beginning of File</span>
@@ -578,6 +598,10 @@
                     <div class="pro-tip">
                         <div class="pro-tip-title">💡 Pro Tip:</div>
                         Select text and use Ctrl+Shift+P → "Transform" to access case transformations, sort lines, and more text manipulation commands!
+                    </div>
+                    <div class="pro-tip">
+                        <div class="pro-tip-title">💡 Pro Tip:</div>
+                        Ensure `editor.formatOnPaste` is enabled in your settings for code to be automatically formatted when you paste it.
                     </div>
                 </div>
             </div>
@@ -750,6 +774,10 @@
                         <span class="keys" data-win="Ctrl + K W" data-mac="Cmd + K W">Ctrl + K W</span>
                     </div>
                     <div class="shortcut">
+                        <span class="shortcut-desc">Move Editor into New Window</span>
+                        <span class="keys" data-win="Ctrl+Shift+P → View: Move Editor into New Window" data-mac="Cmd+Shift+P → View: Move Editor into New Window">Ctrl+Shift+P → View: Move Editor into New Window</span>
+                    </div>
+                    <div class="shortcut">
                         <span class="shortcut-desc">Zen Mode</span>
                         <span class="keys" data-win="Ctrl + K Z" data-mac="Cmd + K Z">Ctrl + K Z</span>
                     </div>
@@ -810,6 +838,10 @@
                     <div class="shortcut">
                         <span class="shortcut-desc">Scroll to Bottom</span>
                         <span class="keys" data-win="Ctrl + End" data-mac="Cmd + End">Ctrl + End</span>
+                    </div>
+                    <div class="shortcut">
+                        <span class="shortcut-desc">Terminal: Clear Scrollback (via Command Palette)</span>
+                        <span class="keys" data-win="Ctrl+Shift+P → Terminal: Clear" data-mac="Cmd+Shift+P → Terminal: Clear">Ctrl+Shift+P → Terminal: Clear</span>
                     </div>
                     <div class="pro-tip">
                         <div class="pro-tip-title">💡 Pro Tip:</div>
@@ -976,6 +1008,10 @@
                     <div class="pro-tip">
                         <div class="pro-tip-title">💡 Pro Tip:</div>
                         Use Ctrl+. for quick fixes and refactoring suggestions. F2 renames all occurrences safely. Ctrl+Shift+O then type ":" to group symbols by category!
+                    </div>
+                    <div class="pro-tip">
+                        <div class="pro-tip-title">💡 Pro Tip:</div>
+                        In the Problems panel (Ctrl+Shift+M or Cmd+Shift+M), you can type directly into it (once focused) to filter errors and warnings by text or file path.
                     </div>
                 </div>
             </div>
@@ -1182,6 +1218,14 @@
                     <div class="shortcut">
                         <span class="shortcut-desc">Developer Tools</span>
                         <span class="keys" data-win="Ctrl + Shift + I" data-mac="Cmd + Alt + I">Ctrl + Shift + I</span>
+                    </div>
+                    <div class="pro-tip">
+                        <div class="pro-tip-title">💡 Pro Tip:</div>
+                        Enable "Sticky Scroll" in Settings (`editor.stickyScroll.enabled`) to keep parent scopes (like function or class names) visible at the top of the editor as you scroll.
+                    </div>
+                    <div class="pro-tip">
+                        <div class="pro-tip-title">💡 Pro Tip:</div>
+                        Explore "Profiles" (accessible via Command Palette: `Profiles: Show Contents`) to create and switch between different sets of settings, extensions, and UI states tailored for specific projects or tasks.
                     </div>
                     <div class="pro-tip">
                         <div class="pro-tip-title">💎 Ultimate Pro Tips:</div>


### PR DESCRIPTION
Adds several useful, lesser-known VS Code shortcuts and tips to the keyboard.html cheat sheet to enhance its value for learners.

New additions include:
- Go to Last Edit Location
- Sticky Scroll feature tip
- Terminal: Clear Scrollback command
- File: Revert File command
- Settings Profiles tip
- Timeline View tip
- Fold/Unfold All Regions shortcuts
- Format on Paste setting tip
- Filter Problems panel tip
- Move Editor into New Window command